### PR TITLE
Switch directory.build.props from APPVEYOR to GITHUB variables

### DIFF
--- a/directory.build.props
+++ b/directory.build.props
@@ -22,8 +22,8 @@
   <!-- Common NuGet package settings -->
   <PropertyGroup Condition="'$(IsPackable)'!='false'">
     <Authors>Oleg Sych</Authors>
-    <Version Condition="'$(APPVEYOR)' == 'True'">$(APPVEYOR_BUILD_VERSION)</Version>
-    <Version Condition="'$(APPVEYOR)' != 'True'">0.0.0</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' != ''">0.2.$(GITHUB_RUN_NUMBER)</Version>
+    <Version Condition="'$(GITHUB_RUN_NUMBER)' == ''">0.0.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Migrating from Appveyor builds to GitHub Actions. GitHub actions don't have an equivalent of the multi-part build numbers, so hardcoding the package version to 0.2.* for now until I implement GitVersion.